### PR TITLE
feat(fishing): Added and fixed things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ UPDATE_REDDIT_POST.md
 
 # OneDrive
 ~$*
+.claude/settings.local.json
+web/package-lock.json

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -51,6 +51,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1209,6 +1210,7 @@
       "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1219,6 +1221,7 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1284,6 +1287,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1542,6 +1546,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1583,6 +1588,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1755,6 +1761,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -51,7 +51,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1210,7 +1209,6 @@
       "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1221,7 +1219,6 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1287,7 +1284,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1546,7 +1542,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1588,7 +1583,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1761,7 +1755,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/web/src/lib/fishing/computeStats.ts
+++ b/web/src/lib/fishing/computeStats.ts
@@ -18,13 +18,13 @@ export interface EffectiveTicksOptions {
   motleySchoolLevel?: number;
   /** Tier 2 Dock Ticks enhancement level: Tier 2 docks only, -1 per level (max 10). */
   enhanceT2DockTicksLevel?: number;
-  /** Abyss Legendary (Cthulhu) caught: Abyss dock -9 ticks. */
+  /** Abyss Legendary (Cthulhu) caught: Tier 1 docks tick req -10%. */
   abyssLegendaryCaught?: boolean;
 }
 
 /**
  * Effective ticks needed to fill the dock meter. Lower = more dock fills per hour = more fish.
- * Reductions: Abyss Legendary T1 (-9), Motley School (Abyss -2/level, T2 -1/level), T2 Dock Ticks Enhance (-1/level for T2).
+ * Reductions: Abyss Legendary T1 (all docks -10%), Motley School (Abyss -2/level, T2 -1/level), T2 Dock Ticks Enhance (-1/level for T2).
  */
 export function getEffectiveTicksNeeded(
   dock: DockDef,
@@ -35,12 +35,12 @@ export function getEffectiveTicksNeeded(
   const abyssT1 = opts.abyssLegendaryCaught === true;
   let ticks = dock.baseTicksNeeded;
   if (dock.id === "abyss") {
-    if (abyssT1) ticks -= 9;
     ticks -= 2 * motley;
   } else if (dock.tier === 2) {
     ticks -= motley;
     ticks -= t2Enhance;
   }
+  if (abyssT1 && dock.tier === 1) ticks = Math.floor(ticks * 0.9);
   return Math.max(1, ticks);
 }
 
@@ -131,9 +131,9 @@ export interface SkillTreeOptions {
   fishersBundle?: boolean;
   /** Store: Angler's Bundle. +6% Tiny Notice Chance (flat). */
   anglerBundle?: boolean;
-  /** Store: Half Way Bundle! Fishing Rod Power ×1.10 (own mult). */
-  halfWayBundle?: boolean;
   /** Divine Challenge Coin: each level gives Shiny Fish Multiplier +10% (own mult). */
+  halfWayBundle?: boolean;
+  /** Store: Half Way Bundle! Fishing Rod Multi 1.10x. */
   divineChallengeCoinLevel?: number;
   /** Construct: Statue Craftmanship. At most one. Gilded = Fish Income ×1.25, Platinized = Fish Income ×1.40 (own mult each). */
   constructStatue?: "none" | "gilded" | "platinized";
@@ -141,6 +141,10 @@ export interface SkillTreeOptions {
   cetusLevel?: number;
   /** Stargazing: Black Hole Bonus. Tier 2 Dock Power +25% (own mult). */
   blackHoleBonus?: boolean;
+  /** Stargazing: Super Stars Fish Income Multiplier. +1.25% per level (max 15, own mult). */
+  superStarsLevel?: number;
+  /** Legendary Fish Tribute: Cthulhu. All docks tick req -10%, Super Shiny Multi +3×. */
+  abyssLegendaryCaught?: boolean;
   /** Cards: Mr Nibbles Card. 0 = none, 1 = Card +1% Tiny Notice, 2 = Gilded +2%, 3 = Poly +4% (flat). */
   mrNibblesCardTier?: number;
 }
@@ -170,8 +174,9 @@ export function computeFishingStatsFromLevels(
   const rodMultiUpgrade = 1 + 0.04 * u("rod_multiplier");
   const rodMultiEnhance = 1 + 0.05 * e("enhance_rod_multiplier");
   const rodMultiMotleySchool = 1 + 0.1 * skill("motley_school");
-  const halfWayBundleMult = options?.halfWayBundle ? 1.1 : 1;
+  const halfWayBundleMult = options?.halfWayBundle ? 1.10 : 1;
   const fishing_rod_power = rodBase * rodMultiUpgrade * rodMultiEnhance * rodMultiMotleySchool * halfWayBundleMult;
+  
 
   // Fish Income Multiplier: upgrade and enhancement are separate factors; the two skills (Fishing With Friends, With This Fish) add together into one factor (additive, not multiplicative).
   // (1 + 0.03×upgrade) × (1 + 0.05×enhance) × (1 + 0.03×Fishing With Friends + 0.01×With This Fish×cards).
@@ -194,7 +199,7 @@ export function computeFishingStatsFromLevels(
   const cetusLevel = Math.max(0, Math.floor(options?.cetusLevel ?? 0));
   const cetusFishIncomeMult = 1 + 0.02 * cetusLevel;
   const fish_income_multi =
-    fishIncomeBase * (options?.legendaryHaulerBundle ? 1.1 : 1) * constructMult * cetusFishIncomeMult;
+    fishIncomeBase * (options?.legendaryHaulerBundle ? 1.1 : 1) * constructMult * cetusFishIncomeMult * (1 + 0.0125 * Math.max(0, Math.min(15, Math.floor(options?.superStarsLevel ?? 0))));
 
   // Tick reduction: each level reduces tick by 0.5s. Base 60s. Skill: Let's Pick Up The Pace -2s per level.
   const fishing_tick_reduction =
@@ -210,9 +215,9 @@ export function computeFishingStatsFromLevels(
   const droneBase = Math.round(droneBaseRaw);
   const droneMultiUpgrade = 1 + 0.06 * u("drone_multiplier");
   const droneMultiEnhance = 1 + 0.08 * e("enhance_drone_multiplier");
-  const legendary = Math.max(0, Math.min(6, options?.legendaryFishFound ?? 0));
+  const legendary = Math.max(0, Math.min(11, options?.legendaryFishFound ?? 0));
   const droneMultFwf = 1 + 0.1 * skill("fishing_with_friends");
-  const droneMultCompletionist = 1 + 0.02 * skill("completionist_gatekeeper") * legendary;
+  const droneMultCompletionist = 1 + (0.02 * skill("completionist_gatekeeper")) * legendary;
   const workshopDroneMultiWorld3 = 1 + 0.02 * Math.max(0, Math.floor(options?.fishingDroneBasePowerWorld3 ?? 0));
   const tethysIdol = Math.max(0, Math.floor(options?.tethysIdolLevel ?? 0));
   const tethysDroneMult = 1 + 0.0005 * tethysIdol; // +0.05% per level; applies to all docks
@@ -240,7 +245,7 @@ export function computeFishingStatsFromLevels(
     3 * e("enhance_fishing_drone_3") +
     5 * skill("fishing_with_friends") +
     5 * skill("motley_school");
-  const fishing_drone_cap = capFromUpgradesAndEnhancements * Math.pow(1.05, u("drone_cloner"));
+  const fishing_drone_cap = capFromUpgradesAndEnhancements * (1 + 0.05 * u("drone_cloner"));
 
   // Token Gain Multiplier: only from enhancement +0.05x per level.
   const token_gain_multi = 1 + 0.05 * e("enhance_token_multiplier");
@@ -281,37 +286,61 @@ export function computeFishingStatsFromLevels(
   const tinyNoticeFromMrNibblesCard = mrNibblesCardTier === 1 ? 1 : mrNibblesCardTier === 2 ? 2 : mrNibblesCardTier === 3 ? 4 : 0;
   const tiny_notice_chance_pct = 0.5 * e("enhance_tiny_notice_chance") + (options?.anglerBundle ? 6 : 0) + tinyNoticeFromMrNibblesCard;
 
-  // Tier 2 Dock Power: fishing upgrades + enhance add in one factor; skill tree (Completionist) is a separate factor × store × pets × cards × archaeology × stargazing (wiki: separate menus multiply).
-  const tier2FishingMenuFactor = 1 + 0.05 * u("tier2_dock_power") + 0.05 * e("enhance_tier2_dock_power");
-  const tier2SkillTreeFactor = 1 + 0.03 * skill("completionist_gatekeeper") * legendary;
+  // --- TIER 2 DOCK POWER CALCULATION ---
+  // Different menus are multiplicative. Within the Fishing menu, Upgrade and Enhancement are additive ('+').
+
+  // 1. Fishing Menu: Upgrade + Enhancement (additive within menu)
+  const tier2FishingMenuFactor = 1 +
+    0.05 * u("tier2_dock_power") +
+    0.05 * e("enhance_tier2_dock_power");
+
+  // 2. Skill-Tree Menu (multiplicative against other menus)
+  const tier2SkillTreeFactor = 1 +
+    0.03 * skill("completionist_gatekeeper") * legendary;
+
+  // 3. Archaeology Menu
+  const archaeologyFactor = 1 + (0.0005 * tethysIdol);
+
+  // 4. Pets Menu (Mr Nibbles Quest)
   const mrNibblesQuestUnlocked = Boolean(options?.mrNibblesQuestUnlocked);
   const mrNibblesQuestRank = Math.max(0, Math.floor(options?.mrNibblesQuestRank ?? 0));
   const mrNibblesQuestMult = mrNibblesQuestUnlocked ? 1 + 0.05 * (mrNibblesQuestRank + 1) : 1;
+
+  // 5. Card Menu (Infernal Angler)
   const infernalAnglerPct = Math.max(0, Number(options?.infernalAnglerDronePct ?? 0));
   const infernalAnglerLvl = Math.max(0, Math.floor(options?.infernalAnglerDroneLevel ?? 0));
+  const cardFactor = 1 + (infernalAnglerPct * infernalAnglerLvl) / 100;
+
+  // 6. Store Menu (Legendary Hauler)
+  const storeFactor = options?.legendaryHaulerBundle ? 1.10 : 1;
+
+  // 7. Stargazing Menu (Black Hole)
+  const stargazingFactor = options?.blackHoleBonus ? 1.25 : 1;
+
+  // FINAL: each menu factor is multiplicative
   const tier2_dock_power_mult =
     tier2FishingMenuFactor *
     tier2SkillTreeFactor *
-    (1 + 0.0005 * tethysIdol) *
-    (options?.legendaryHaulerBundle ? 1.1 : 1) *
+    archaeologyFactor *
     mrNibblesQuestMult *
-    (1 + (infernalAnglerPct * infernalAnglerLvl) / 100) *
-    (options?.blackHoleBonus ? 1.25 : 1);
+    cardFactor *
+    storeFactor *
+    stargazingFactor;
 
   // Shiny Multiplier: base 5×, +5% per level (T2 upgrade and enhance; additive mult: 1 + 0.05×level each). Pets: Mr Nibbles +0.03× per level (own mult). Divine Challenge Coin: +10% per level (own mult).
   const shinyBase = 5 * (1 + 0.05 * u("shiny_multiplier")) * (1 + 0.05 * e("enhance_shiny_multiplier"));
   const divineChallengeCoinLevel = Math.max(0, Math.floor(options?.divineChallengeCoinLevel ?? 0));
   const shiny_multiplier = shinyBase * (1 + 0.03 * mrNibblesLevel) * (1 + 0.1 * divineChallengeCoinLevel);
 
-  // Super Shiny Multiplier: base 3× (only when catch is already shiny), +0.08x (poly_card_multi), +0.15x (enhance). Tethys Idol +0.05% per level (global, all docks).
+  // Super Shiny Multiplier: base 3× (only when catch is already shiny), +0.08x (poly_card_multi), +0.15x (enhance), +3 (Cthulhu tribute). Tethys Idol +0.05% per level (global, all docks).
   const superShinyBase = 3 +
     0.08 * u("poly_card_multi") +
-    0.15 * e("enhance_super_shiny_multi");
+    0.15 * e("enhance_super_shiny_multi") +
+    (options?.abyssLegendaryCaught ? 3 : 0);
   const super_shiny_multiplier = superShinyBase * (1 + 0.0005 * tethysIdol);
 
   // Poly card gain multi: applies to fish card gains (Card 1.5×, Gilded 2×). Polychrome Potency Bundle fish poly ×1.15 in UI.
   const poly_card_gain_multi =
-    1 +
     0.08 * u("poly_card_multi") +
     0.1 * e("enhance_poly_card_multi");
 

--- a/web/src/lib/fishing/constants.ts
+++ b/web/src/lib/fishing/constants.ts
@@ -17,6 +17,11 @@ export function upgradeIconUrl(iconFile: string): string {
   return fishIconUrl(iconFile);
 }
 
+/** URL for notice fish requirement icon (same wiki File: namespace). */
+export function fishReqIconUrl(iconFile: string): string {
+  return fishIconUrl(iconFile);
+}
+
 /** URL for enhancement icon (same wiki File: namespace). */
 export function enhanceIconUrl(iconFile: string): string {
   return fishIconUrl(iconFile);

--- a/web/src/lib/fishing/index.ts
+++ b/web/src/lib/fishing/index.ts
@@ -43,6 +43,7 @@ export {
   fishIconUrl,
   dockIconUrl,
   upgradeIconUrl,
+  fishReqIconUrl,
   enhanceIconUrl,
   getDock,
   getFishById,

--- a/web/src/lib/fishing/skillTree.ts
+++ b/web/src/lib/fishing/skillTree.ts
@@ -22,6 +22,7 @@ export const FISHING_SKILL_TREE: FishingSkillDef[] = [
     id: "friendship_ended_tier1",
     name: "Friendship Ended With Tier 1 Items",
     iconFile: "Friendship_Ended_With_Tier_1_Items.png",
+    statIconFile: "Notice_Fish_Requirement.png",
     obeliskLevel: 37,
     effectLines: [
       "Tier 2 Items From Expert Notices +2",
@@ -73,7 +74,7 @@ export const FISHING_SKILL_TREE: FishingSkillDef[] = [
     iconFile: "Completionist_Gatekeeper.png",
     obeliskLevel: 50,
     effectLines: [
-      "Per Legendary Fish Found (1-6):",
+      "Per Legendary Fish Found (1-11):",
       "Tier 2 Dock Power +3%",
       "Fishing Drone Power +2%",
       "Super Shiny Fish Chance +1%",

--- a/web/src/lib/fishing/types.ts
+++ b/web/src/lib/fishing/types.ts
@@ -198,6 +198,8 @@ export interface FishingSkillDef {
   name: string;
   /** Wiki icon filename (e.g. "Fishing_With_Friends.png"). */
   iconFile: string;
+  /** Optional wiki icon filename for a stat related to the skill (e.g. "Notice_Fish_Requirement.png"). */
+  statIconFile?: string;
   /** Obelisk level required to unlock. */
   obeliskLevel: number;
   /** Short effect lines for tooltip/display. */

--- a/web/src/lib/fishing/upgradeCosts.ts
+++ b/web/src/lib/fishing/upgradeCosts.ts
@@ -164,7 +164,9 @@ const super_shiny_chance: UpgradeCostEntry[] = [
 const poly_card_multi: UpgradeCostEntry[] = [
   cost(1, "625k", "lanternfish_comet"), cost(2, "750k", "lanternfish_comet"), cost(3, "900k", "ufo"), cost(4, "1.08m", "ufo"), cost(5, "1.30m", "sub_solar_squid"),
   cost(6, "1.56m", "sub_solar_squid"), cost(7, "1.87m", "planetary_jellyfish"), cost(8, "2.24m", "planetary_jellyfish"), cost(9, "2.69m", "molten_archerfish"), cost(10, "3.22m", "molten_archerfish"),
-  cost(11, "3.87m", "lava_snail"), cost(12, "4.64m", "lava_snail"), cost(13, "5.57m", "obsidian_tooth_barracuda"),
+  cost(11, "3.87m", "lava_snail"), cost(12, "4.64m", "lava_snail"), cost(13, "5.57m", "obsidian_tooth_barracuda"), cost(14, "6.69m", "obsidian_tooth_barracuda"), cost(15, "8.02m", "basalturtle"),
+  cost(16, "9.63m", "basalturtle"), cost(17, "11.6m", "planetary_jellyfish"), cost(18, "13.9m", "planetary_jellyfish"), cost(19, "16.6m", "heliocentric_clam"), cost(20, "20.0m", "heliocentric_clam"),
+  cost(21, "24.0m", "gamma_rayburst_shrimp"), cost(22, "28.8m", "gamma_rayburst_shrimp"), cost(23, "34.5m", "galaxia_whale"), cost(24, "41.4m", "galaxia_whale"), cost(25, "49.7m", "dark_matter_blackdragon")
 ];
 
 const drone_cloner: UpgradeCostEntry[] = [

--- a/web/src/modules/fishing/Fishing.tsx
+++ b/web/src/modules/fishing/Fishing.tsx
@@ -40,6 +40,7 @@ import {
   FISHING_ROD_GILD_CARD_COST,
   upgradeIconUrl,
   enhanceIconUrl,
+  fishReqIconUrl,
   UPGRADE_COSTS,
   type DockId,
   type EnhanceId,
@@ -78,7 +79,7 @@ type SavedState = {
   valuePackPotencyPoly?: boolean;
   skillTreeLevels?: Partial<Record<FishingSkillId, number>>;
   legendaryFishFound?: number;
-  /** Abyss Legendary (Cthulhu) caught: Abyss dock tick req -9 (more dock fills/h). */
+  /** Abyss Legendary (Cthulhu) tribute 1: All docks tick req -10% and Super Shiny Multi +3× */
   abyssLegendaryCaught?: boolean;
   /** Divine Relic points: +2% 5× tick chance per point (applies to all gains; Sushi does not get Gift +25%). */
   divineRelic5xPoints?: number;
@@ -115,6 +116,8 @@ type SavedState = {
   cetusLevel?: number;
   /** Stargazing: Black Hole Bonus. Tier 2 Dock Power +25%. */
   blackHoleBonus?: boolean;
+  /** Stargazing: Super Stars Fish Income Multiplier. +1.25% per level (max 15). */
+  superStarsLevel?: number;
   /** Upgrades: Fishing Drone Power (World 3). +0.1 base drone power per level. */
   droneBasePowerWorld3Upgrade?: number;
   /** Cards: Infernal Mr Nibbles — % per level (flat 5× tick chance). */
@@ -148,7 +151,7 @@ type FishingState = {
   valuePackPotencyPoly: boolean;
   skillTreeLevels: Partial<Record<FishingSkillId, number>>;
   legendaryFishFound: number;
-  /** Abyss Legendary (Cthulhu) caught: Abyss dock tick req -9 (more dock fills/h). */
+  /** Abyss Legendary (Cthulhu) tribute 1: All docks tick req -10% and Super Shiny Multi +3× */
   abyssLegendaryCaught: boolean;
   /** Divine Relic points: +2% 5× tick chance per point. */
   divineRelic5xPoints: number;
@@ -194,6 +197,8 @@ type FishingState = {
   cetusLevel: number;
   /** Stargazing: Black Hole Bonus. Tier 2 Dock Power +25%. */
   blackHoleBonus: boolean;
+  /** Stargazing: Super Stars Fish Income Multiplier. +1.25% per level (max 15). */
+  superStarsLevel: number;
   /** Cards: Infernal Mr Nibbles — % per level (flat 5× tick chance). */
   infernalMrNibblesPct: number;
   /** Cards: Infernal Mr Nibbles — level. */
@@ -257,6 +262,7 @@ function getDefaultFishingState(): FishingState {
     constructStatue: "none",
     cetusLevel: 0,
     blackHoleBonus: false,
+    superStarsLevel: 0,
     infernalMrNibblesPct: 0,
     infernalMrNibblesLevel: 0,
     infernalAnglerDronePct: 0,
@@ -454,8 +460,8 @@ function formatUpgradeNextEffect(
     }
     case "drone_cloner": {
       const lvl = Math.floor(Number(upgradeLevels?.drone_cloner ?? 0));
-      const curFactor = Math.pow(1.05, lvl);
-      const nextFactor = Math.pow(1.05, lvl + 1);
+      const curFactor = 1 + 0.05 * lvl;
+      const nextFactor = 1 + 0.05 * (lvl + 1);
       return `${curFactor.toFixed(2)}×→${nextFactor.toFixed(2)}×`;
     }
     case "shiny_multiplier": {
@@ -602,7 +608,7 @@ type TotalFishOptions = {
   skillTreeLevels?: Partial<Record<FishingSkillId, number>>;
   fishCardTier?: Partial<Record<string, number>>;
   legendaryFishFound?: number;
-  /** Abyss Legendary (Cthulhu) caught: Abyss dock tick req -9. */
+  /** Abyss Legendary (Cthulhu) tribute 1: All docks tick req -10% and Super Shiny Multi +3× */
   abyssLegendaryCaught?: boolean;
   /** Fishing Rod card tier (0–3) for rod power mult 1 / 1.02 / 1.05 / 1.10. */
   fishingRodCardTier?: FishCardTier;
@@ -628,6 +634,7 @@ type TotalFishOptions = {
   constructStatue?: "none" | "gilded" | "platinized";
   cetusLevel?: number;
   blackHoleBonus?: boolean;
+  superStarsLevel?: number;
 };
 
 /**
@@ -976,17 +983,21 @@ function StepperRow(props: {
 function StatRow(props: {
   label: string;
   iconUrl?: string;
+  statIconUrl?: string;
   value: number;
   decimals?: number;
   suffix?: string;
 }) {
-  const { label, iconUrl, value, decimals = 0, suffix = "" } = props;
+  const { label, iconUrl, statIconUrl, value, decimals = 0, suffix = "" } = props;
   const displayValue = Number.isFinite(value) ? value.toFixed(decimals) : "—";
   return (
     <div className="fishingRow fishingRowInline">
       <div className="fishingLabelLeft">
         {iconUrl ? (
           <img src={iconUrl} alt="" className="iconSmall" style={{ width: 18, height: 18, objectFit: "contain" }} />
+        ) : null}
+        {statIconUrl ? (
+          <img src={statIconUrl} alt="" className="iconSmall" style={{ width: 18, height: 18, objectFit: "contain" }} />
         ) : null}
         <span className="fishingLabelName">{label}</span>
       </div>
@@ -1206,7 +1217,7 @@ export function Fishing() {
     const sushiCardTier = clamp(Math.trunc(Number(saved?.sushiCardTier ?? 0)), 0, 3) as FishCardTier;
     const valuePackPotencyPoly = saved?.valuePackPotencyPoly ?? false;
     const skillTreeLevels = saved?.skillTreeLevels ?? {};
-    const legendaryFishFound = clamp(Number(saved?.legendaryFishFound ?? 0), 0, 6);
+    const legendaryFishFound = clamp(Number(saved?.legendaryFishFound ?? 0), 0, 11);
     const abyssLegendaryCaught = Boolean(saved?.abyssLegendaryCaught ?? false);
     const fishingRodCardTier = clamp(Math.trunc(Number(saved?.fishingRodCardTier ?? 0)), 0, 3) as FishCardTier;
     const mrNibblesCardTier = clamp(Math.trunc(Number(saved?.mrNibblesCardTier ?? 0)), 0, 3) as FishCardTier;
@@ -1239,12 +1250,13 @@ export function Fishing() {
       constructStatueRaw === "gilded" || constructStatueRaw === "platinized" ? constructStatueRaw : "none";
     const cetusLevel = Math.max(0, Math.trunc(Number(saved?.cetusLevel ?? 0)));
     const blackHoleBonus = Boolean(saved?.blackHoleBonus ?? false);
+    const superStarsLevel = Math.max(0, Math.min(15, Math.trunc(Number(saved?.superStarsLevel ?? 0))));
     const droneBasePowerWorld3Upgrade = Math.max(0, Math.trunc(Number(saved?.droneBasePowerWorld3Upgrade ?? 0)));
     const infernalMrNibblesPct = Math.max(0, Number(saved?.infernalMrNibblesPct ?? 0));
     const infernalMrNibblesLevel = Math.max(0, Math.trunc(Number(saved?.infernalMrNibblesLevel ?? 0)));
     const infernalAnglerDronePct = Math.max(0, Number(saved?.infernalAnglerDronePct ?? 0));
     const infernalAnglerDroneLevel = Math.max(0, Math.trunc(Number(saved?.infernalAnglerDroneLevel ?? 0)));
-    return { dronesPerDock, showDisabledFishGrayed, showPolyShardDroprate, useGemIncomeForCostEffic, activeDockId, upgradeLevels, enhanceLevels, fishCardTier, sushiCardTier, fishingRodCardTier, mrNibblesCardTier, valuePackPotencyPoly, skillTreeLevels, legendaryFishFound, abyssLegendaryCaught, divineRelic5xPoints, mcHours, mcRuns, sushiMcSushis, mrNibblesLevel, mrNibblesQuestUnlocked, mrNibblesQuestRank, mrNibblesSkin, poseidonIdolLevel, tethysIdolLevel, astraeusIdolLevel, droneBasePowerWorld3Upgrade, fishingDroneBasePowerWorld3, workshopSushiTicksWorld3, legendaryHaulerBundle, fishersBundle, anglerBundle, halfWayBundle, divineChallengeCoinLevel, constructStatue, cetusLevel, blackHoleBonus, infernalMrNibblesPct, infernalMrNibblesLevel, infernalAnglerDronePct, infernalAnglerDroneLevel };
+    return { dronesPerDock, showDisabledFishGrayed, showPolyShardDroprate, useGemIncomeForCostEffic, activeDockId, upgradeLevels, enhanceLevels, fishCardTier, sushiCardTier, fishingRodCardTier, mrNibblesCardTier, valuePackPotencyPoly, skillTreeLevels, legendaryFishFound, abyssLegendaryCaught, divineRelic5xPoints, mcHours, mcRuns, sushiMcSushis, mrNibblesLevel, mrNibblesQuestUnlocked, mrNibblesQuestRank, mrNibblesSkin, poseidonIdolLevel, tethysIdolLevel, astraeusIdolLevel, droneBasePowerWorld3Upgrade, fishingDroneBasePowerWorld3, workshopSushiTicksWorld3, legendaryHaulerBundle, fishersBundle, anglerBundle, halfWayBundle, divineChallengeCoinLevel, constructStatue, cetusLevel, blackHoleBonus, superStarsLevel, infernalMrNibblesPct, infernalMrNibblesLevel, infernalAnglerDronePct, infernalAnglerDroneLevel };
   });
 
   useEffect(() => {
@@ -1300,6 +1312,8 @@ export function Fishing() {
     constructStatue: state.constructStatue,
     cetusLevel: state.cetusLevel,
     blackHoleBonus: state.blackHoleBonus,
+    superStarsLevel: state.superStarsLevel,
+    abyssLegendaryCaught: state.abyssLegendaryCaught,
     infernalMrNibblesPct: state.infernalMrNibblesPct,
     infernalMrNibblesLevel: state.infernalMrNibblesLevel,
     infernalAnglerDronePct: state.infernalAnglerDronePct,
@@ -1832,6 +1846,7 @@ export function Fishing() {
       constructStatue: state.constructStatue,
       cetusLevel: state.cetusLevel,
       blackHoleBonus: state.blackHoleBonus,
+      superStarsLevel: state.superStarsLevel,
     };
     const greedy = getGreedyDockAssignment(upgradeLevels, enhanceLevels, skillOpts, elixir3xFishingExternal, extraTicksPerHour);
     const dockIds = new Set(availableDocks.map((d) => d.id));
@@ -1905,6 +1920,7 @@ export function Fishing() {
     state.constructStatue,
     state.cetusLevel,
     state.blackHoleBonus,
+    state.superStarsLevel,
     elixir3xFishingExternal,
     extraTicksPerHour,
     availableDocks,
@@ -2327,6 +2343,7 @@ export function Fishing() {
       constructStatue: state.constructStatue,
       cetusLevel: state.cetusLevel,
       blackHoleBonus: state.blackHoleBonus,
+      superStarsLevel: state.superStarsLevel,
     };
     const currentStats = computeFishingStatsFromLevels(upgradeLevels, enhanceLevels, skillOpts);
     // Greedy: +% gains assume rod and all drones on the dock that maximizes total fish/h.
@@ -2466,6 +2483,7 @@ export function Fishing() {
       constructStatue: state.constructStatue,
       cetusLevel: state.cetusLevel,
       blackHoleBonus: state.blackHoleBonus,
+      superStarsLevel: state.superStarsLevel,
     };
     const greedy0 = getGreedyDockAssignment(upgradeLevels, enhanceLevels, skillOpts, elixir3xFishingExternal, extraTicksPerHour);
     const currentTotal = computeTotalFishPerHour(
@@ -2566,6 +2584,7 @@ export function Fishing() {
       constructStatue: state.constructStatue,
       cetusLevel: state.cetusLevel,
       blackHoleBonus: state.blackHoleBonus,
+      superStarsLevel: state.superStarsLevel,
     };
     const greedy = getGreedyDockAssignment(upgradeLevels, enhanceLevels, skillOpts, elixir3xFishingExternal, extraTicksPerHour);
     const currentTotal = computeTotalFishPerHour(
@@ -2619,6 +2638,7 @@ export function Fishing() {
     state.constructStatue,
     state.cetusLevel,
     state.blackHoleBonus,
+    state.superStarsLevel,
     elixir3xFishingExternal,
     extraTicksPerHour,
   ]);
@@ -2653,6 +2673,7 @@ export function Fishing() {
       constructStatue: state.constructStatue,
       cetusLevel: state.cetusLevel,
       blackHoleBonus: state.blackHoleBonus,
+      superStarsLevel: state.superStarsLevel,
     };
     const currentTotal = computeTotalFishPerHour(
       upgradeLevels,
@@ -2704,6 +2725,7 @@ export function Fishing() {
     state.constructStatue,
     state.cetusLevel,
     state.blackHoleBonus,
+    state.superStarsLevel,
     elixir3xFishingExternal,
     extraTicksPerHour,
   ]);
@@ -2737,6 +2759,7 @@ export function Fishing() {
       constructStatue: state.constructStatue,
       cetusLevel: state.cetusLevel,
       blackHoleBonus: state.blackHoleBonus,
+      superStarsLevel: state.superStarsLevel,
     };
     const currentTotal = computeTotalFishPerHour(
       upgradeLevels,
@@ -2789,6 +2812,7 @@ export function Fishing() {
     state.constructStatue,
     state.cetusLevel,
     state.blackHoleBonus,
+    state.superStarsLevel,
     elixir3xFishingExternal,
     extraTicksPerHour,
   ]);
@@ -2824,6 +2848,7 @@ export function Fishing() {
       constructStatue: state.constructStatue,
       cetusLevel: state.cetusLevel,
       blackHoleBonus: state.blackHoleBonus,
+      superStarsLevel: state.superStarsLevel,
     };
     const greedy = getGreedyDockAssignment(upgradeLevels, enhanceLevels, skillOpts, elixir3xFishingExternal, extraTicksPerHour);
     const currentTotal = computeTotalFishPerHour(
@@ -2943,6 +2968,7 @@ export function Fishing() {
     state.constructStatue,
     state.cetusLevel,
     state.blackHoleBonus,
+    state.superStarsLevel,
     elixir3xFishingExternal,
     extraTicksPerHour,
     visibleGainsRows,
@@ -3085,6 +3111,7 @@ export function Fishing() {
       constructStatue: state.constructStatue,
       cetusLevel: state.cetusLevel,
       blackHoleBonus: state.blackHoleBonus,
+      superStarsLevel: state.superStarsLevel,
     };
     const currentStats = computeFishingStatsFromLevels(upgradeLevels, enhanceLevels, skillOpts);
     // Greedy: +% gains assume rod and all drones on the dock that maximizes total fish/h.
@@ -3274,7 +3301,7 @@ export function Fishing() {
     let rodCostEffic: number | null = null;
     let rodCostEfficGemAbs: number | null = null;
     const cardToGildedRatio = 2 / 1.5; // Card 1.5× → Gilded 2×
-    const skillOptsBase = { skillTreeLevels: state.skillTreeLevels ?? {}, legendaryFishFound: state.legendaryFishFound, relic5xPoints: state.divineRelic5xPoints, mrNibblesLevel: state.mrNibblesLevel, mrNibblesQuestUnlocked: state.mrNibblesQuestUnlocked, mrNibblesQuestRank: state.mrNibblesQuestRank, mrNibblesSkin: state.mrNibblesSkin, poseidonIdolLevel: state.poseidonIdolLevel, tethysIdolLevel: state.tethysIdolLevel, astraeusIdolLevel: state.astraeusIdolLevel, droneBasePowerWorld3Upgrade: state.droneBasePowerWorld3Upgrade, fishingDroneBasePowerWorld3: state.fishingDroneBasePowerWorld3, mrNibblesCardTier: state.mrNibblesCardTier, legendaryHaulerBundle: state.legendaryHaulerBundle, fishersBundle: state.fishersBundle, anglerBundle: state.anglerBundle, halfWayBundle: state.halfWayBundle, divineChallengeCoinLevel: state.divineChallengeCoinLevel, infernalMrNibblesPct: state.infernalMrNibblesPct, infernalMrNibblesLevel: state.infernalMrNibblesLevel, infernalAnglerDronePct: state.infernalAnglerDronePct, infernalAnglerDroneLevel: state.infernalAnglerDroneLevel, constructStatue: state.constructStatue, cetusLevel: state.cetusLevel, blackHoleBonus: state.blackHoleBonus };
+    const skillOptsBase = { skillTreeLevels: state.skillTreeLevels ?? {}, legendaryFishFound: state.legendaryFishFound, relic5xPoints: state.divineRelic5xPoints, mrNibblesLevel: state.mrNibblesLevel, mrNibblesQuestUnlocked: state.mrNibblesQuestUnlocked, mrNibblesQuestRank: state.mrNibblesQuestRank, mrNibblesSkin: state.mrNibblesSkin, poseidonIdolLevel: state.poseidonIdolLevel, tethysIdolLevel: state.tethysIdolLevel, astraeusIdolLevel: state.astraeusIdolLevel, droneBasePowerWorld3Upgrade: state.droneBasePowerWorld3Upgrade, fishingDroneBasePowerWorld3: state.fishingDroneBasePowerWorld3, mrNibblesCardTier: state.mrNibblesCardTier, legendaryHaulerBundle: state.legendaryHaulerBundle, fishersBundle: state.fishersBundle, anglerBundle: state.anglerBundle, halfWayBundle: state.halfWayBundle, divineChallengeCoinLevel: state.divineChallengeCoinLevel, infernalMrNibblesPct: state.infernalMrNibblesPct, infernalMrNibblesLevel: state.infernalMrNibblesLevel, infernalAnglerDronePct: state.infernalAnglerDronePct, infernalAnglerDroneLevel: state.infernalAnglerDroneLevel, constructStatue: state.constructStatue, cetusLevel: state.cetusLevel, blackHoleBonus: state.blackHoleBonus, superStarsLevel: state.superStarsLevel };
     const legFishIds = new Set(LEGENDARY_FISH.map((leg) => leg.id));
     const dockIdsAvailable = new Set(availableDocks.map((d) => d.id));
     const droneCap = Math.floor(stats.fishing_drone_cap);
@@ -3412,6 +3439,7 @@ export function Fishing() {
       constructStatue: state.constructStatue,
       cetusLevel: state.cetusLevel,
       blackHoleBonus: state.blackHoleBonus,
+      superStarsLevel: state.superStarsLevel,
     };
     const greedy = getGreedyDockAssignment(upgradeLevels, enhanceLevels, skillOpts, elixir3xFishingExternal, extraTicksPerHour);
     const currentTotal = computeTotalFishPerHour(
@@ -3466,6 +3494,7 @@ export function Fishing() {
     state.constructStatue,
     state.cetusLevel,
     state.blackHoleBonus,
+    state.superStarsLevel,
     elixir3xFishingExternal,
     extraTicksPerHour,
   ]);
@@ -3502,6 +3531,7 @@ export function Fishing() {
       constructStatue: state.constructStatue,
       cetusLevel: state.cetusLevel,
       blackHoleBonus: state.blackHoleBonus,
+      superStarsLevel: state.superStarsLevel,
     };
     const greedy = getGreedyDockAssignment(upgradeLevels, enhanceLevels, skillOpts, elixir3xFishingExternal, extraTicksPerHour);
     const currentTotal = computeTotalFishPerHour(
@@ -3556,6 +3586,7 @@ export function Fishing() {
     state.constructStatue,
     state.cetusLevel,
     state.blackHoleBonus,
+    state.superStarsLevel,
     elixir3xFishingExternal,
     extraTicksPerHour,
   ]);
@@ -4445,7 +4476,7 @@ export function Fishing() {
                                     `Upgrade (1 + 0.06×lvl): ×${stats.drone_power_multiplier_breakdown.upgrade.toFixed(2)}`,
                                     `Enhance (1 + 0.08×lvl): ×${stats.drone_power_multiplier_breakdown.enhance.toFixed(2)}`,
                                     `FWF (1 + 0.1×lvl): ×${stats.drone_power_multiplier_breakdown.fwf.toFixed(2)}`,
-                                    `Completionist (1 + 0.02×lvl×leg): ×${stats.drone_power_multiplier_breakdown.completionist.toFixed(2)}`,
+                                    `Completionist (1 + (0.02×lvl)×leg): ×${stats.drone_power_multiplier_breakdown.completionist.toFixed(2)}`,
                                     `Workshop World 3 (1 + 0.02×lvl): ×${stats.drone_power_multiplier_breakdown.workshop.toFixed(2)}`,
                                     `Tethys Idol (1 + 0.05%×lvl): ×${stats.drone_power_multiplier_breakdown.tethys.toFixed(4)}`,
                                     `Total: ×${stats.drone_power_multiplier.toFixed(2)}`,
@@ -4459,6 +4490,13 @@ export function Fishing() {
                     </div>
                     <span className="mono fishingRowValue">{Number.isFinite(stats.drone_power_multiplier) ? stats.drone_power_multiplier.toFixed(2) : "—"}×</span>
                   </div>
+                  <StatRow
+                    label="Tier 2 Dock Power"
+                    iconUrl={upgradeIconUrl("Tier_2_Dock_Power.png")}
+                    value={stats.tier2_dock_power_mult}
+                    decimals={2}
+                    suffix="×"
+                  />
                   <StatRow
                     label="Fish Income Multi"
                     iconUrl={upgradeIconUrl("Fish_Income_Multiplier.png")}
@@ -4487,6 +4525,8 @@ export function Fishing() {
                     decimals={2}
                     suffix="%"
                   />
+                </div>
+                <div className="fishingStatsCol">
                   <StatRow
                     label="5× Tick Chance"
                     iconUrl={upgradeIconUrl("5x_Fish_Tick_Chance.png")}
@@ -4501,10 +4541,9 @@ export function Fishing() {
                     decimals={2}
                     suffix="×"
                   />
-                </div>
-                <div className="fishingStatsCol">
                   <StatRow
                     label="Notice Fish Req"
+                    statIconUrl={fishReqIconUrl("Notice_Fish_Requirement.png")}
                     value={stats.notice_fish_req}
                     decimals={2}
                     suffix="×"
@@ -4541,13 +4580,6 @@ export function Fishing() {
                     label="Super Shiny Multi"
                     iconUrl={upgradeIconUrl("Super_Shiny_Multiplier.png")}
                     value={stats.super_shiny_multiplier}
-                    decimals={2}
-                    suffix="×"
-                  />
-                  <StatRow
-                    label="Tier 2 Dock Power"
-                    iconUrl={upgradeIconUrl("Tier_2_Dock_Power.png")}
-                    value={stats.tier2_dock_power_mult}
                     decimals={2}
                     suffix="×"
                   />
@@ -5847,41 +5879,6 @@ export function Fishing() {
           <div className="small" style={{ marginBottom: 8 }}>
             Skills cost skill points (from Obelisk level). 1 skill point = 125 gems. Cost efficiency = marginal % per hour to earn gem cost (uses Gem EV Calculator). Open Gem EV to sync.
           </div>
-          <div className="fishingSkillOptions">
-            <div className="fishingSkillOptionRow">
-              <img src={SKILL_POINT_ICON_URL} alt="" style={{ width: 20, height: 20, objectFit: "contain", flexShrink: 0 }} />
-              <span>Legendary Fish Found (0–6)</span>
-              <div className="fishingSkillOptionStepper">
-                <span className="fishingUpgradeLevelLabel">
-                  <span className="mono">{state.legendaryFishFound}</span> / 6
-                </span>
-                <div className="btnRow fishingUpgradeButtons">
-                  <button type="button" className="btn btnSecondary" onClick={() => setState((p) => ({ ...p, legendaryFishFound: Math.max(0, p.legendaryFishFound - 1) }))} disabled={state.legendaryFishFound <= 0} aria-label="Decrease">−</button>
-                  <button type="button" className="btn" onClick={() => setState((p) => ({ ...p, legendaryFishFound: Math.min(6, p.legendaryFishFound + 1) }))} disabled={state.legendaryFishFound >= 6} aria-label="Increase">+</button>
-                </div>
-              </div>
-            </div>
-            <div className="small" style={{ marginTop: 0, marginBottom: 2, opacity: 0.85 }}>Used for Completionist Gatekeeper bonus.</div>
-            <div className="fishingSkillOptionRow">
-              <input
-                type="checkbox"
-                id="fishing-abyss-legendary-caught"
-                checked={state.abyssLegendaryCaught}
-                onChange={(e) => setState((p) => ({ ...p, abyssLegendaryCaught: e.target.checked }))}
-                style={{ flexShrink: 0 }}
-              />
-              <label htmlFor="fishing-abyss-legendary-caught" style={{ cursor: "pointer", marginBottom: 0 }}>Abyss Legendary (Cthulhu) caught</label>
-              <Tooltip
-                content={{
-                  title: "Abyss Legendary caught",
-                  sections: [
-                    { heading: "Effect", lines: ["When checked: Abyss dock tick requirement −9 (30 → 21). More dock fills per hour on Abyss = more fish/h."] },
-                    { heading: "Source", lines: ["Unlock from catching the Abyss legendary fish (Cthulhu) once."] },
-                  ],
-                }}
-              />
-            </div>
-          </div>
           <div className="fishingUpgradesList">
             <table className="fishingUpgradeTable">
               <thead>
@@ -6097,6 +6094,22 @@ export function Fishing() {
                 })}
               </tbody>
             </table>
+            <div className="fishingSkillOptions">
+              <div className="fishingSkillOptionRow">
+                <img src={SKILL_POINT_ICON_URL} alt="" style={{ width: 20, height: 20, objectFit: "contain", flexShrink: 0 }} />
+                <span>Legendary Fish Found (0–11)</span>
+                <div className="fishingSkillOptionStepper">
+                  <span className="fishingUpgradeLevelLabel">
+                    <span className="mono">{state.legendaryFishFound}</span> / 11
+                  </span>
+                  <div className="btnRow fishingUpgradeButtons">
+                    <button type="button" className="btn btnSecondary" onClick={() => setState((p) => ({ ...p, legendaryFishFound: Math.max(0, p.legendaryFishFound - 1) }))} disabled={state.legendaryFishFound <= 0} aria-label="Decrease">−</button>
+                    <button type="button" className="btn" onClick={() => setState((p) => ({ ...p, legendaryFishFound: Math.min(11, p.legendaryFishFound + 1) }))} disabled={state.legendaryFishFound >= 11} aria-label="Increase">+</button>
+                  </div>
+                </div>
+              </div>
+              <div className="small" style={{ marginTop: 0, marginBottom: 2, opacity: 0.85 }}>Used for Completionist Gatekeeper bonus.</div>
+            </div>
           </div>
         </Collapsible>
 
@@ -6384,6 +6397,35 @@ export function Fishing() {
                 }}
               />
               <StepperRow
+                label="Astraeus Idol"
+                iconUrl="https://static.wikitide.net/shminerwiki/1/1c/Astraeus_Idol.png"
+                value={state.astraeusIdolLevel}
+                min={0}
+                max={999}
+                onChange={(n) => setState((prev) => ({ ...prev, astraeusIdolLevel: Math.max(0, n) }))}
+                tooltipContent={{
+                  title: "Astraeus Idol",
+                  sections: [
+                    {
+                      heading: "Effect",
+                      lines: [
+                        "Archaeology: +0.03% Fishing double tick chance per level (flat, added on top of existing double tick chance).",
+                      ],
+                    },
+                    {
+                      heading: "+1 level (effective fish gain)",
+                      lines: [
+                        astraeusIdolMarginalFishPct != null
+                          ? `About +${Math.abs(astraeusIdolMarginalFishPct) < 0.01 ? astraeusIdolMarginalFishPct.toFixed(4) : Math.abs(astraeusIdolMarginalFishPct) < 0.1 ? astraeusIdolMarginalFishPct.toFixed(3) : astraeusIdolMarginalFishPct.toFixed(2)}% total fish/h at your current build.`
+                          : "No active docks with fish gain; +% cannot be computed.",
+                      ],
+                    },
+                  ],
+                }}
+                effectText={`→ +${(state.astraeusIdolLevel * 0.03).toFixed(2)}% double tick chance`}
+                inputClassName="fishingStepperLevelInputWide"
+              />
+                            <StepperRow
                 label="Tethys Idol"
                 iconUrl="https://static.wikitide.net/shminerwiki/a/a4/Tethys_Idol.png"
                 value={state.tethysIdolLevel}
@@ -6419,35 +6461,6 @@ export function Fishing() {
                   </>
                 }
               />
-              <StepperRow
-                label="Astraeus Idol"
-                iconUrl="https://static.wikitide.net/shminerwiki/1/1c/Astraeus_Idol.png"
-                value={state.astraeusIdolLevel}
-                min={0}
-                max={999}
-                onChange={(n) => setState((prev) => ({ ...prev, astraeusIdolLevel: Math.max(0, n) }))}
-                tooltipContent={{
-                  title: "Astraeus Idol",
-                  sections: [
-                    {
-                      heading: "Effect",
-                      lines: [
-                        "Archaeology: +0.03% Fishing double tick chance per level (flat, added on top of existing double tick chance).",
-                      ],
-                    },
-                    {
-                      heading: "+1 level (effective fish gain)",
-                      lines: [
-                        astraeusIdolMarginalFishPct != null
-                          ? `About +${Math.abs(astraeusIdolMarginalFishPct) < 0.01 ? astraeusIdolMarginalFishPct.toFixed(4) : Math.abs(astraeusIdolMarginalFishPct) < 0.1 ? astraeusIdolMarginalFishPct.toFixed(3) : astraeusIdolMarginalFishPct.toFixed(2)}% total fish/h at your current build.`
-                          : "No active docks with fish gain; +% cannot be computed.",
-                      ],
-                    },
-                  ],
-                }}
-                effectText={`→ +${(state.astraeusIdolLevel * 0.03).toFixed(2)}% double tick chance`}
-                inputClassName="fishingStepperLevelInputWide"
-              />
             </div>
 
             <div className="fishingUpgradesBlock" style={{ marginTop: 10 }}>
@@ -6477,6 +6490,40 @@ export function Fishing() {
                 effectText={`→ +${state.divineRelic5xPoints * 2}% 5× tick chance`}
                 inputClassName="fishingStepperLevelInputWide"
               />
+            </div>
+
+            <div className="fishingUpgradesBlock" style={{ marginTop: 10 }}>
+              <div className="fishingBlockHeader">
+                <span className="fishingBlockHeaderTitle">Legendary Fish Tributes</span>
+              </div>
+              <div className="fishingStepperRow">
+                <div className="fishingStepperNameBlock">
+                  <img src="https://static.wikitide.net/shminerwiki/6/6f/Abyss_Legendary_Fish.png" alt="" className="fishingUpgradeIcon" aria-hidden />
+                  <div className="fishingStepperLabelBlock">
+                    <span className="fishingStepperRowLabel">Cthulhu</span>
+                    <Tooltip
+                      content={{
+                        title: "Cthulhu Tribute 1",
+                        lines: ["All Dock Tick Reqs -10%", "Super Shiny Multi +3x"],
+                      }}
+                      label="?"
+                    />
+                  </div>
+                </div>
+                <div className="fishingStepperLvlBlock">
+                  <label className="fishingStepperCheckboxWrap" style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <input
+                      type="checkbox"
+                      id="fishing-abyss-legendary-caught"
+                      className="fishingCheckbox"
+                      checked={state.abyssLegendaryCaught}
+                      onChange={(e) => setState((prev) => ({ ...prev, abyssLegendaryCaught: e.target.checked }))}
+                    />
+                    <span className="fishingUpgradeLevelLabel">on</span>
+                  </label>
+                </div>
+                <span className="mono fishingStepperEffect">{state.abyssLegendaryCaught ? "→ All Dock Tick Reqs -10%, Super Shiny Multi +3×" : "—"}</span>
+              </div>
             </div>
 
             <div className="fishingUpgradesBlock" style={{ marginTop: 10 }}>
@@ -6595,6 +6642,20 @@ export function Fishing() {
                   ],
                 }}
                 effectText={`→ Fish Income ×${(1 + 0.02 * state.cetusLevel).toFixed(2)} (+${state.cetusLevel * 2}%)`}
+                inputClassName="fishingStepperLevelInputWide"
+              />
+              <StepperRow
+                label="Fish Income Multiplier"
+                iconUrl="https://static.wikitide.net/shminerwiki/7/78/Fish_Income_Multiplier.png"
+                value={state.superStarsLevel}
+                min={0}
+                max={15}
+                onChange={(n) => setState((prev) => ({ ...prev, superStarsLevel: Math.max(0, Math.min(15, n)) }))}
+                tooltipContent={{
+                  title: "Super Stars: Fish Income Multiplier",
+                  lines: ["Each level gives Fish Income +1.25% (own multiplier)."],
+                }}
+                effectText={`→ Fish Income ×${(1 + 0.0125 * state.superStarsLevel).toFixed(4)} (+${(state.superStarsLevel * 1.25).toFixed(2)}%)`}
                 inputClassName="fishingStepperLevelInputWide"
               />
               <div className="fishingCheckboxRow">


### PR DESCRIPTION
- Introduced `fishReqIconUrl` function to generate URLs for notice fish requirement icons.
- Updated `FishingSkillDef` interface to include an optional `statIconFile` icon.
- Adjusted the maximum legendary fish found from 6 to 11 and updated related UI components.
- Implemented missing super stars upgrade for fish income multiplier, with UI adjustments for skill options.
- Fixed Fishing Tick Reduction calculations.
- Fixed Cthulu unlock option to match in-game behavior.
- Made slight adjustments to option locations.